### PR TITLE
Add ClearML support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+ENV CLEARML__API__API_SERVER=http://localhost:8008 \
+    CLEARML__API__WEB_SERVER=http://localhost:8080 \
+    CLEARML__API__FILES_SERVER=http://localhost:8081
+COPY . .
+CMD ["python", "-m", "scripts.run_experiment", "--device", "cpu", "--amp"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ The code targets **Python 3.12** and relies on the following packages (see
 For development and testing you may also install the tools listed in
 `requirements-dev.txt` (`pytest`, `black`, `ruff`).
 
-## Running the experiment
+## Usage
+
+### Running the experiment
 
 Install the requirements and install the package in editable mode, then run the
 experiment module from the project root:
@@ -55,3 +57,30 @@ To verify a germination log, use the ``kaslog`` tool:
 ```bash
 python -m kaslog verify germination.jsonl
 ```
+
+### Docker
+
+The project ships with a `Dockerfile` and `docker-compose.yml`. Build and run
+the experiment in a container with:
+
+```bash
+docker compose up
+```
+
+The compose service runs `python -m scripts.run_experiment --device cpu --amp` by
+default. Edit `docker-compose.yml` to pass additional arguments if needed.
+
+
+### Experiment Tracking with ClearML
+
+The experiment automatically logs to a local ClearML Server. Set the following
+environment variables to override the defaults:
+
+```bash
+export CLEARML__API__API_SERVER=http://localhost:8008
+export CLEARML__API__WEB_SERVER=http://localhost:8080
+export CLEARML__API__FILES_SERVER=http://localhost:8081
+```
+
+A minimal fallback configuration is provided in `conf/clearml.conf`. Once the
+server is running, open the UI at `http://localhost:8080` to inspect your runs.

--- a/conf/clearml.conf
+++ b/conf/clearml.conf
@@ -1,0 +1,5 @@
+api {
+    api_server: http://localhost:8008
+    web_server: http://localhost:8080
+    files_server: http://localhost:8081
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+services:
+  app:
+    build: .
+    command: python -m scripts.run_experiment --device cpu --amp
+    environment:
+      - CLEARML__API__API_SERVER
+      - CLEARML__API__WEB_SERVER
+      - CLEARML__API__FILES_SERVER

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 scikit-learn
 torch
 torchvision
+clearml>=1.8.4

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1,5 +1,8 @@
 """Run a morphogenetic architecture experiment on the two spirals dataset."""
 
+from clearml import Task
+Task.init(project_name="kasima-cifar", task_name="two-spirals")
+
 import json
 import random
 import numpy as np

--- a/tests/test_clearml.py
+++ b/tests/test_clearml.py
@@ -1,0 +1,35 @@
+import sys
+import types
+
+import importlib
+import os
+
+
+def test_clearml_initialisation(monkeypatch):
+    # Create a stub clearml module with a Task class
+    clearml_stub = types.ModuleType("clearml")
+
+    class DummyTask:
+        init_args = None
+
+        @classmethod
+        def init(cls, project_name, task_name):
+            cls.init_args = (project_name, task_name)
+            return cls
+
+        @classmethod
+        def current_task(cls):
+            return True
+
+    clearml_stub.Task = DummyTask
+    monkeypatch.setitem(sys.modules, "clearml", clearml_stub)
+
+    sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+    if "scripts.run_experiment" in sys.modules:
+        del sys.modules["scripts.run_experiment"]
+    import scripts.run_experiment as _  # noqa: F401
+
+    assert DummyTask.init_args == ("kasima-cifar", "two-spirals")
+    assert DummyTask.current_task()
+


### PR DESCRIPTION
## Summary
- add ClearML to requirements and Docker image
- initialise ClearML in `run_experiment`
- honour ClearML server variables and ship a default config
- provide docker-compose environment passthrough
- document experiment tracking
- add mocked ClearML tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684df46886108323a1148389458ddafa