### PR TITLE
Add ClearML support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir clearml
+COPY . .
+ENV CLEARML__API__API_SERVER=${CLEARML__API__API_SERVER}
+ENV CLEARML__API__WEB_SERVER=${CLEARML__API__WEB_SERVER}
+ENV CLEARML__API__FILES_SERVER=${CLEARML__API__FILES_SERVER}
+CMD ["python", "-m", "scripts.run_experiment", "--device", "cpu", "--amp"]

--- a/README.md
+++ b/README.md
@@ -55,3 +55,39 @@ To verify a germination log, use the ``kaslog`` tool:
 ```bash
 python -m kaslog verify germination.jsonl
 ```
+
+## Docker
+
+The project ships with a `Dockerfile` and `docker-compose.yml`. Build and run
+the experiment in a container with:
+
+```bash
+docker compose up
+```
+
+The compose service runs `python -m scripts.run_experiment --device cpu --amp` by
+default. Edit `docker-compose.yml` to pass additional arguments if needed.
+
+## Experiment Tracking with ClearML
+
+Every run automatically initialises a ClearML Task. To log your experiments to a
+local ClearML Server set the following environment variables:
+
+```bash
+export CLEARML__API__API_SERVER=http://localhost:8008
+export CLEARML__API__WEB_SERVER=http://localhost:8080
+export CLEARML__API__FILES_SERVER=http://localhost:8081
+```
+
+Alternatively copy and edit `clearml.conf`:
+
+```conf
+api {
+    api_server: http://localhost:8008
+    web_server: http://localhost:8080
+    files_server: http://localhost:8081
+}
+```
+
+Open `http://localhost:8080` in your browser to view the web UI.
+

--- a/clearml.conf
+++ b/clearml.conf
@@ -1,0 +1,5 @@
+api {
+    api_server: http://localhost:8008
+    web_server: http://localhost:8080
+    files_server: http://localhost:8081
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+services:
+  app:
+    build: .
+    command: python -m scripts.run_experiment --device cpu --amp
+    environment:
+      - CLEARML__API__API_SERVER
+      - CLEARML__API__WEB_SERVER
+      - CLEARML__API__FILES_SERVER

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 scikit-learn
 torch
 torchvision
+clearml>=1.8.4

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1,5 +1,9 @@
 """Run a morphogenetic architecture experiment on the two spirals dataset."""
 
+from clearml import Task
+
+Task.init(project_name="kasima-cifar", task_name="run_experiment")
+
 import json
 import random
 import numpy as np

--- a/tests/test_clearml.py
+++ b/tests/test_clearml.py
@@ -1,0 +1,25 @@
+import importlib
+import os
+import sys
+
+import clearml
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_task_init_called(monkeypatch):
+    called = {}
+
+    def fake_init(project_name, task_name):
+        called["project"] = project_name
+        called["task"] = task_name
+        clearml.Task.current_task = staticmethod(lambda: "dummy")
+        return "dummy"
+
+    monkeypatch.setattr(clearml.Task, "init", fake_init)
+    if "scripts.run_experiment" in sys.modules:
+        del sys.modules["scripts.run_experiment"]
+    module = importlib.import_module("scripts.run_experiment")
+    assert called["project"] == "kasima-cifar"
+    assert called["task"] == "run_experiment"
+    assert module.Task.current_task() == "dummy"


### PR DESCRIPTION
## Summary
- add ClearML dependency and minimal config file
- initialise ClearML Task in run_experiment
- expose ClearML environment variables in Docker setup
- document ClearML usage in README
- test ClearML integration with mocks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684df46886108323a1148389458ddafa